### PR TITLE
Port to QFAPI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+//file:noinspection GroovyAccessibility
+//file:noinspection GroovyAssignabilityCheck
 buildscript {
 	repositories {
 		gradlePluginPortal()
@@ -53,12 +55,13 @@ processResources {
 		"mc"             : libs.versions.mc.get(),
 		"ql"             : libs.versions.ql.get(),
 		"qsl"            : libs.versions.qsl.get(),
+		"fapi"           : libs.versions.fapi.get(),
 		"qfapi"          : libs.versions.qfapi.get(),
 		"emi"            : libs.versions.emi.get()
 	]
 
 	inputs.properties(map)
-	filesMatching('quilt.mod.json') { expand(map) }
+	filesMatching('*.mod.json') { expand(map) }
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ dependencyResolutionManagement {
 		libs {
 			def mc_major = '1.19'
 			def mc = mc_major + '.2'
+			def fapi = "0.76.0"
 
 			// // Build Tools // //
 			version('loom', '1.2.+')
@@ -29,7 +30,8 @@ dependencyResolutionManagement {
 			version('ql', "0.19.0")
 			version('qm', "${mc}+build.22")
 			version('qsl', "3.0.0-beta.29+${mc}")
-			version('qfapi', "4.0.0-beta.30+0.76.0-${mc}")
+			version('fapi', "${fapi}-${mc}")
+			version('qfapi', "4.0.0-beta.30+${fapi}-${mc}")
 
 			library('mc', 'mojang', 'minecraft').versionRef('mc')
 			library('ql', 'org.quiltmc', 'quilt-loader').versionRef('ql')

--- a/src/main/java/folk/sisby/tinkerers_smithing/TinkerersSmithing.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/TinkerersSmithing.java
@@ -8,6 +8,10 @@ import folk.sisby.tinkerers_smithing.recipe.SacrificeUpgradeRecipe;
 import folk.sisby.tinkerers_smithing.recipe.ShapelessRepairRecipe;
 import folk.sisby.tinkerers_smithing.recipe.ShapelessUpgradeRecipe;
 import folk.sisby.tinkerers_smithing.recipe.SmithingUpgradeRecipe;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.minecraft.item.Item;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.recipe.SpecialRecipeSerializer;
@@ -17,14 +21,10 @@ import net.minecraft.tag.TagKey;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import org.jetbrains.annotations.Nullable;
-import org.quiltmc.loader.api.ModContainer;
-import org.quiltmc.qsl.base.api.entrypoint.ModInitializer;
-import org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents;
-import org.quiltmc.qsl.resource.loader.api.ResourceLoader;
-import org.quiltmc.qsl.resource.loader.api.ResourceLoaderEvents;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("deprecation")
 public class TinkerersSmithing implements ModInitializer {
 	public static final String ID = "tinkerers_smithing";
 	public static final Logger LOGGER = LoggerFactory.getLogger(ID);
@@ -36,7 +36,7 @@ public class TinkerersSmithing implements ModInitializer {
 	public static final SpecialRecipeSerializer<SacrificeUpgradeRecipe> SACRIFICE_UPGRADE_SERIALIZER = Registry.register(Registry.RECIPE_SERIALIZER, new Identifier(ID, "crafting_special_sacrifice_upgrade"), new SpecialRecipeSerializer<>(SacrificeUpgradeRecipe::new));
 
 	// Discarded and picked up each reload. Probably shouldn't be accessed outside of reload time.
-	private static TinkerersSmithingLoader LOADER_INSTANCE = null;
+	private static TinkerersSmithingLoader LOADER_INSTANCE = new TinkerersSmithingLoader();
 
 	public static TinkerersSmithingLoader getLoaderInstance() {
 		return LOADER_INSTANCE;
@@ -46,6 +46,7 @@ public class TinkerersSmithing implements ModInitializer {
 
 	private static void generateSmithingData(MinecraftServer server) {
 		if (server != null) {
+			TinkerersSmithing.LOGGER.info("[Tinkerer's Smithing] Generating Smithing Data!");
 			getLoaderInstance().generateItemSmithingData(server);
 			LOADER_INSTANCE = null;
 			SMITHING_RELOAD_BUF = TinkerersSmithingNetworking.createSmithingReloadBuf();
@@ -54,19 +55,21 @@ public class TinkerersSmithing implements ModInitializer {
 	}
 
 	private static void resetLoader() {
+		TinkerersSmithing.LOGGER.info("[Tinkerer's Smithing] Resetting Loader!");
 		SMITHING_RELOAD_BUF = null;
 		LOADER_INSTANCE = new TinkerersSmithingLoader();
 	}
 
 	@Override
-	public void onInitialize(ModContainer mod) {
-		ResourceLoaderEvents.START_DATA_PACK_RELOAD.register((server, oldResourceManager) -> TinkerersSmithing.resetLoader());
-		ServerLifecycleEvents.READY.register(TinkerersSmithing::generateSmithingData);
-		ResourceLoaderEvents.END_DATA_PACK_RELOAD.register((server, resourceManager, throwable) -> TinkerersSmithing.generateSmithingData(server));
-		ResourceLoader.get(ResourceType.SERVER_DATA).registerReloader(SmithingToolMaterialLoader.INSTANCE);
-		ResourceLoader.get(ResourceType.SERVER_DATA).registerReloader(SmithingArmorMaterialLoader.INSTANCE);
-		ResourceLoader.get(ResourceType.SERVER_DATA).registerReloader(SmithingUnitCostManager.INSTANCE);
-		ResourceLoader.get(ResourceType.SERVER_DATA).registerReloader(SmithingTypeLoader.INSTANCE);
+	public void onInitialize() {
+		ServerPlayConnectionEvents.JOIN.register((TinkerersSmithingNetworking::onPlayReady));
+		ServerLifecycleEvents.START_DATA_PACK_RELOAD.register((server, oldResourceManager) -> TinkerersSmithing.resetLoader());
+		ServerLifecycleEvents.SERVER_STARTED.register(TinkerersSmithing::generateSmithingData);
+		ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, resourceManager, throwable) -> TinkerersSmithing.generateSmithingData(server));
+		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(SmithingToolMaterialLoader.INSTANCE);
+		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(SmithingArmorMaterialLoader.INSTANCE);
+		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(SmithingUnitCostManager.INSTANCE);
+		ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(SmithingTypeLoader.INSTANCE);
 
 		LOGGER.info("[Tinkerer's Smithing] Initialized.");
 	}

--- a/src/main/java/folk/sisby/tinkerers_smithing/TinkerersSmithingNetworking.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/TinkerersSmithingNetworking.java
@@ -1,20 +1,20 @@
 package folk.sisby.tinkerers_smithing;
 
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.item.Item;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
-import org.quiltmc.qsl.networking.api.PacketByteBufs;
-import org.quiltmc.qsl.networking.api.PacketSender;
-import org.quiltmc.qsl.networking.api.ServerPlayConnectionEvents;
-import org.quiltmc.qsl.networking.api.ServerPlayNetworking;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class TinkerersSmithingNetworking implements ServerPlayConnectionEvents.Join {
+@SuppressWarnings("deprecation")
+public class TinkerersSmithingNetworking {
 	public static final Identifier S2C_SMITHING_RELOAD = new Identifier(TinkerersSmithing.ID, "s2c_smithing_reload");
 
 	public static PacketByteBuf createSmithingReloadBuf() {
@@ -38,8 +38,8 @@ public class TinkerersSmithingNetworking implements ServerPlayConnectionEvents.J
 		});
 	}
 
-	@Override
-	public void onPlayReady(ServerPlayNetworkHandler handler, PacketSender sender, MinecraftServer server) {
+	@SuppressWarnings("unused")
+	public static void onPlayReady(ServerPlayNetworkHandler handler, PacketSender sender, MinecraftServer server) {
 		if (ServerPlayNetworking.canSend(handler, S2C_SMITHING_RELOAD) && TinkerersSmithing.SMITHING_RELOAD_BUF != null) {
 			ServerPlayNetworking.send(handler.getPlayer(), S2C_SMITHING_RELOAD, TinkerersSmithing.SMITHING_RELOAD_BUF);
 		}

--- a/src/main/java/folk/sisby/tinkerers_smithing/client/TinkerersSmithingClient.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/client/TinkerersSmithingClient.java
@@ -1,22 +1,22 @@
 package folk.sisby.tinkerers_smithing.client;
 
 import folk.sisby.tinkerers_smithing.TinkerersSmithingItemData;
+import net.fabricmc.api.ClientModInitializer;
 import net.minecraft.item.Item;
-import org.quiltmc.loader.api.ModContainer;
-import org.quiltmc.qsl.base.api.entrypoint.client.ClientModInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@SuppressWarnings("deprecation")
 public class TinkerersSmithingClient implements ClientModInitializer {
 	public static final Logger LOGGER = LoggerFactory.getLogger("tinkerers_smithing_client");
 
 	public static final Map<Item, TinkerersSmithingItemData> SERVER_SMITHING_ITEMS = new HashMap<>();
 
 	@Override
-	public void onInitializeClient(ModContainer mod) {
+	public void onInitializeClient() {
 		TinkerersSmithingClientNetworking.initializeReceivers();
 	}
 }

--- a/src/main/java/folk/sisby/tinkerers_smithing/client/TinkerersSmithingClientNetworking.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/client/TinkerersSmithingClientNetworking.java
@@ -2,16 +2,17 @@ package folk.sisby.tinkerers_smithing.client;
 
 import folk.sisby.tinkerers_smithing.TinkerersSmithingItemData;
 import folk.sisby.tinkerers_smithing.TinkerersSmithingNetworking;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.fabricmc.loader.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.network.PacketByteBuf;
-import org.quiltmc.loader.api.QuiltLoader;
-import org.quiltmc.qsl.networking.api.PacketSender;
-import org.quiltmc.qsl.networking.api.client.ClientPlayNetworking;
 
+@SuppressWarnings("deprecation")
 public class TinkerersSmithingClientNetworking {
 	public static void initializeReceivers() {
-		if (QuiltLoader.isModLoaded("emi")) {
+		if (FabricLoader.INSTANCE.isModLoaded("emi")) {
 			ClientPlayNetworking.registerGlobalReceiver(TinkerersSmithingNetworking.S2C_SMITHING_RELOAD, TinkerersSmithingClientNetworking::smithingReload);
 		}
 	}

--- a/src/main/java/folk/sisby/tinkerers_smithing/data/SmithingArmorMaterialLoader.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/data/SmithingArmorMaterialLoader.java
@@ -3,17 +3,18 @@ package folk.sisby.tinkerers_smithing.data;
 import com.google.gson.Gson;
 import folk.sisby.tinkerers_smithing.TinkerersSmithing;
 import folk.sisby.tinkerers_smithing.TinkerersSmithingMaterial;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.ArmorMaterial;
 import net.minecraft.item.Item;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
-import org.quiltmc.qsl.resource.loader.api.reloader.IdentifiableResourceReloader;
 
 import java.util.Map;
 
-public class SmithingArmorMaterialLoader extends SmithingMaterialLoader implements IdentifiableResourceReloader {
+@SuppressWarnings("deprecation")
+public class SmithingArmorMaterialLoader extends SmithingMaterialLoader implements IdentifiableResourceReloadListener {
 	public static final SmithingArmorMaterialLoader INSTANCE = new SmithingArmorMaterialLoader(new Gson());
 	public static final Identifier ID = new Identifier(TinkerersSmithing.ID, "smithing_armor_material_loader");
 
@@ -46,7 +47,7 @@ public class SmithingArmorMaterialLoader extends SmithingMaterialLoader implemen
 	}
 
 	@Override
-	public @NotNull Identifier getQuiltId() {
+	public @NotNull Identifier getFabricId() {
 		return ID;
 	}
 }

--- a/src/main/java/folk/sisby/tinkerers_smithing/data/SmithingMaterialLoader.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/data/SmithingMaterialLoader.java
@@ -51,6 +51,7 @@ public abstract class SmithingMaterialLoader extends MultiJsonDataLoader {
 
 	@Override
 	protected void apply(Map<Identifier, Collection<Pair<JsonElement, String>>> prepared, ResourceManager manager, Profiler profiler) {
+		TinkerersSmithing.LOGGER.info("[Tinkerer's Smithing] Loading Materials!");
 		Map<Identifier, TinkerersSmithingMaterial> outputMap = this.getOutputMap();
 		Map<Identifier, List<Identifier>> upgradeFromMap = new HashMap<>();
 		prepared.forEach((id, jsons) -> {

--- a/src/main/java/folk/sisby/tinkerers_smithing/data/SmithingToolMaterialLoader.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/data/SmithingToolMaterialLoader.java
@@ -3,17 +3,18 @@ package folk.sisby.tinkerers_smithing.data;
 import com.google.gson.Gson;
 import folk.sisby.tinkerers_smithing.TinkerersSmithing;
 import folk.sisby.tinkerers_smithing.TinkerersSmithingMaterial;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.minecraft.item.Item;
 import net.minecraft.item.ToolItem;
 import net.minecraft.item.ToolMaterial;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
-import org.quiltmc.qsl.resource.loader.api.reloader.IdentifiableResourceReloader;
 
 import java.util.Map;
 
-public class SmithingToolMaterialLoader extends SmithingMaterialLoader implements IdentifiableResourceReloader {
+@SuppressWarnings("deprecation")
+public class SmithingToolMaterialLoader extends SmithingMaterialLoader implements IdentifiableResourceReloadListener {
 	public static final SmithingToolMaterialLoader INSTANCE = new SmithingToolMaterialLoader(new Gson());
 	public static final Identifier ID = new Identifier(TinkerersSmithing.ID, "smithing_tool_material_loader");
 
@@ -46,7 +47,7 @@ public class SmithingToolMaterialLoader extends SmithingMaterialLoader implement
 	}
 
 	@Override
-	public @NotNull Identifier getQuiltId() {
+	public @NotNull Identifier getFabricId() {
 		return ID;
 	}
 }

--- a/src/main/java/folk/sisby/tinkerers_smithing/data/SmithingTypeLoader.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/data/SmithingTypeLoader.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonElement;
 import com.mojang.serialization.Dynamic;
 import com.mojang.serialization.JsonOps;
 import folk.sisby.tinkerers_smithing.TinkerersSmithing;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.Item;
 import net.minecraft.resource.ResourceManager;
@@ -17,12 +18,12 @@ import net.minecraft.util.profiler.Profiler;
 import net.minecraft.util.registry.Registry;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.quiltmc.qsl.resource.loader.api.reloader.IdentifiableResourceReloader;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class SmithingTypeLoader extends MultiJsonDataLoader implements IdentifiableResourceReloader {
+@SuppressWarnings("deprecation")
+public class SmithingTypeLoader extends MultiJsonDataLoader implements IdentifiableResourceReloadListener {
 	public static final SmithingTypeLoader INSTANCE = new SmithingTypeLoader(new Gson());
 	public static final Identifier ID = new Identifier(TinkerersSmithing.ID, "smithing_type_loader");
 	public static final TagGroupLoader<Item> ITEM_TAG_LOADER = new TagGroupLoader<>(Registry.ITEM::getOrEmpty, "tags/items");
@@ -33,7 +34,7 @@ public class SmithingTypeLoader extends MultiJsonDataLoader implements Identifia
 	}
 
 	@Override
-	public @NotNull Identifier getQuiltId() {
+	public @NotNull Identifier getFabricId() {
 		return ID;
 	}
 
@@ -46,6 +47,7 @@ public class SmithingTypeLoader extends MultiJsonDataLoader implements Identifia
 
 	@Override
 	protected void apply(Map<Identifier, Collection<Pair<JsonElement, String>>> prepared, ResourceManager manager, Profiler profiler) {
+		TinkerersSmithing.LOGGER.info("[Tinkerer's Smithing] Loading Types!");
 		Map<Identifier, List<TagGroupLoader.EntryWithSource>> typeTags = new HashMap<>();
 		prepared.forEach((id, jsons) -> {
 			Identifier collisionAvoidingID = new Identifier(id.getNamespace(), AVOIDANCE_PREFIX + id.getPath());

--- a/src/main/java/folk/sisby/tinkerers_smithing/data/SmithingUnitCostManager.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/data/SmithingUnitCostManager.java
@@ -3,6 +3,7 @@ package folk.sisby.tinkerers_smithing.data;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import folk.sisby.tinkerers_smithing.TinkerersSmithing;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.resource.JsonDataLoader;
 import net.minecraft.resource.ResourceManager;
@@ -10,12 +11,12 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.profiler.Profiler;
 import net.minecraft.util.registry.Registry;
 import org.jetbrains.annotations.NotNull;
-import org.quiltmc.qsl.resource.loader.api.reloader.IdentifiableResourceReloader;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class SmithingUnitCostManager extends JsonDataLoader implements IdentifiableResourceReloader {
+@SuppressWarnings("deprecation")
+public class SmithingUnitCostManager extends JsonDataLoader implements IdentifiableResourceReloadListener {
 	public static final SmithingUnitCostManager INSTANCE = new SmithingUnitCostManager(new Gson());
 	public static final Identifier ID = new Identifier(TinkerersSmithing.ID, "smithing_unit_cost_loader");
 
@@ -29,28 +30,27 @@ public class SmithingUnitCostManager extends JsonDataLoader implements Identifia
 
 	@Override
 	protected void apply(Map<Identifier, JsonElement> prepared, ResourceManager manager, Profiler profiler) {
-		prepared.forEach((id, json) -> {
-			Registry.ITEM.getOrEmpty(id).ifPresentOrElse(item -> {
-				boolean replace = json.getAsJsonObject().get(KEY_REPLACE).getAsBoolean();
-				Map<Ingredient, Integer> costs = new HashMap<>();
-				json.getAsJsonObject().get(KEY_VALUES).getAsJsonArray().forEach(jsonValue -> {
-					Ingredient ingredient = Ingredient.fromJson(jsonValue.getAsJsonObject());
-					int cost = jsonValue.getAsJsonObject().get(KEY_VALUE_COST).getAsInt();
-					costs.put(ingredient, cost);
-				});
-				TinkerersSmithing.getLoaderInstance().COST_OVERRIDES.put(item, new UnitCostOverride(replace, costs));
-			}, () -> {
-				TinkerersSmithing.LOGGER.warn("[Tinkerer's Smithing] Failed to override cost for invalid item {}", id);
+		TinkerersSmithing.LOGGER.info("[Tinkerer's Smithing] Loading Unit Costs!");
+		prepared.forEach((id, json) -> Registry.ITEM.getOrEmpty(id).ifPresentOrElse(item -> {
+			boolean replace = json.getAsJsonObject().get(KEY_REPLACE).getAsBoolean();
+			Map<Ingredient, Integer> costs = new HashMap<>();
+			json.getAsJsonObject().get(KEY_VALUES).getAsJsonArray().forEach(jsonValue -> {
+				Ingredient ingredient = Ingredient.fromJson(jsonValue.getAsJsonObject());
+				int cost = jsonValue.getAsJsonObject().get(KEY_VALUE_COST).getAsInt();
+				costs.put(ingredient, cost);
 			});
-		});
+			TinkerersSmithing.getLoaderInstance().COST_OVERRIDES.put(item, new UnitCostOverride(replace, costs));
+		}, () -> TinkerersSmithing.LOGGER.warn("[Tinkerer's Smithing] Failed to override cost for invalid item {}", id)));
 		TinkerersSmithing.LOGGER.info("[Tinkerer's Smithing] Reloaded unit cost overrides");
 	}
 
 	@Override
-	public @NotNull Identifier getQuiltId() {
+	public @NotNull Identifier getFabricId() {
 		return ID;
 	}
 
 	public record UnitCostOverride(boolean replace, Map<Ingredient, Integer> costs) {
 	}
+
+
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": 1,
+  "id": "tinkerers_smithing",
+  "version": "${version}",
+  "name": "Tinkerer's Smithing",
+  "description": "A sentimental and convenient rebalance of gear crafting, repair, enchanting, and smithing.",
+  "authors": [
+    "Sisby folk"
+  ],
+  "contact": {
+    "homepage": "https://modrinth.com/mod/tinkerers-smithing",
+    "issues": "https://github.com/sisby-folk/tinkerers-smithing/issues",
+    "sources": "https://github.com/sisby-folk/tinkerers-smithing"
+  },
+  "license": "LGPL-3.0-only",
+  "icon": "assets/tinkerers_smithing/icon.png",
+  "environment": "*",
+  "entrypoints": {
+    "main": [
+      "folk.sisby.tinkerers_smithing.TinkerersSmithing"
+    ],
+    "client": [
+      "folk.sisby.tinkerers_smithing.client.TinkerersSmithingClient"
+    ],
+    "emi": [
+      "folk.sisby.tinkerers_smithing.client.emi.TinkerersSmithingPlugin"
+    ]
+  },
+  "depends": {
+    "fabricloader": ">=0.14.9",
+    "minecraft": ">=${mc}",
+    "fabric": ">=${fapi}"
+  },
+  "suggests": {
+    "emi": ">=${emi}"
+  },
+  "mixins": [
+    "tinkerers_smithing.mixins.json"
+  ]
+}

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -19,13 +19,10 @@
 			"icon": "assets/tinkerers_smithing/icon.png"
 		},
 		"entrypoints": {
-			"init": [
+			"main": [
 				"folk.sisby.tinkerers_smithing.TinkerersSmithing"
 			],
-			"events": [
-				"folk.sisby.tinkerers_smithing.TinkerersSmithingNetworking"
-			],
-			"client_init": [
+			"client": [
 				"folk.sisby.tinkerers_smithing.client.TinkerersSmithingClient"
 			],
 			"emi": [


### PR DESCRIPTION
That's a weird sentence.

Basically what this means is dropping all QSL references in favour of pure FAPI using a QFAPI dependency. At runtime - this means both work, but we still get to use quilt mappings and toolchain, and we barely have to change shit. Might even work on FFAPI.

Basically it's like adding an FMJ to a mixin-only mod, except it works for mod initializers and reloaders and stuff.