### PR TITLE
Add workaround for KubeJS recipe manager headaches.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,21 @@ archivesBaseName = project.slug
 repositories {
 	maven { url "https://repo.sleeping.town/" }
 	maven { url "https://maven.terraformersmc.com/" }
+	maven {
+		// Shedaniel's maven (Architectury API)
+		url = "https://maven.architectury.dev"
+		content {
+			includeGroup "dev.architectury"
+		}
+	}
+
+	maven {
+		// saps.dev Maven (KubeJS and Rhino)
+		url = "https://maven.saps.dev/minecraft"
+		content {
+			includeGroup "dev.latvian.mods"
+		}
+	}
 }
 
 dependencies {
@@ -27,6 +42,8 @@ dependencies {
 
 	modCompileOnly libs.emi
 	modLocalRuntime libs.emi
+
+	modImplementation("dev.latvian.mods:kubejs-fabric:${kubejs_version}")
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,4 @@ branch=1.20
 tagBranch=1.19
 compatibleVersions=1.20.1
 compatibleLoaders=fabric, quilt, forge
+kubejs_version=2001.6.5-build.16

--- a/src/main/java/folk/sisby/tinkerers_smithing/TinkerersSmithingKubeJSPlugin.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/TinkerersSmithingKubeJSPlugin.java
@@ -1,0 +1,25 @@
+package folk.sisby.tinkerers_smithing;
+
+import dev.latvian.mods.kubejs.KubeJSPlugin;
+import dev.latvian.mods.kubejs.recipe.RecipesEventJS;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeManager;
+import net.minecraft.util.Identifier;
+
+import java.util.Map;
+
+public class TinkerersSmithingKubeJSPlugin extends KubeJSPlugin {
+
+	public void injectRuntimeRecipes(RecipesEventJS event, RecipeManager manager, Map<Identifier, Recipe<?>> recipesByName) {
+		TinkerersSmithing.generateSmithingData(recipesByName);
+		int manualRecipes = 0;
+		for (Recipe<?> recipe : TinkerersSmithingLoader.INSTANCE.RECIPES) {
+			if (!recipesByName.containsKey(recipe.getId())) {
+				recipesByName.put(recipe.getId(), recipe);
+			} else {
+				manualRecipes++;
+			}
+		}
+		TinkerersSmithing.LOGGER.info("[Tinkerer's Smithing] Added {} runtime recipes with {} data overrides!", TinkerersSmithingLoader.INSTANCE.RECIPES.size(), manualRecipes);
+	}
+}

--- a/src/main/java/folk/sisby/tinkerers_smithing/mixin/TinkerersSmithingMixinPlugin.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/mixin/TinkerersSmithingMixinPlugin.java
@@ -1,0 +1,58 @@
+package folk.sisby.tinkerers_smithing.mixin;
+
+import com.google.common.collect.ImmutableMap;
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class TinkerersSmithingMixinPlugin implements IMixinConfigPlugin {
+	private static final Supplier<Boolean> TRUE = () -> true;
+
+	private static final Map<String, Supplier<Boolean>> CONDITIONS = ImmutableMap.of(
+		"folk.sisby.tinkerers_smithing.mixin.RecipeManagerMixin", () -> !FabricLoader.getInstance().isModLoaded("kubejs")
+	);
+
+	@Override
+	public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+		return CONDITIONS.getOrDefault(mixinClassName, TRUE).get();
+	}
+
+	// Boilerplate
+
+	@Override
+	public void onLoad(String mixinPackage) {
+
+	}
+
+	@Override
+	public String getRefMapperConfig() {
+		return null;
+	}
+
+	@Override
+	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+	}
+
+	@Override
+	public List<String> getMixins() {
+		return null;
+	}
+
+	@Override
+	public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+	}
+
+	@Override
+	public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+	}
+
+}

--- a/src/main/resources/kubejs.plugins.txt
+++ b/src/main/resources/kubejs.plugins.txt
@@ -1,0 +1,1 @@
+folk.sisby.tinkerers_smithing.TinkerersSmithingKubeJSPlugin

--- a/src/main/resources/tinkerers_smithing.mixins.json
+++ b/src/main/resources/tinkerers_smithing.mixins.json
@@ -3,6 +3,7 @@
 	"minVersion": "0.8",
 	"package": "folk.sisby.tinkerers_smithing.mixin",
 	"compatibilityLevel": "JAVA_17",
+	"plugin": "folk.sisby.tinkerers_smithing.mixin.TinkerersSmithingMixinPlugin",
 	"mixins": [
 		"AnvilScreenHandlerMixin",
 		"EnchantmentHelperMixin",


### PR DESCRIPTION
KubeJS is naughty and mucks around in Recipe Manager in an incompatible way, as documented in
https://github.com/sisby-folk/tinkerers-smithing/issues/40
This PR implements the suggested workaround from here:
https://github.com/KubeJS-Mods/KubeJS/issues/822

tl;dr
 * adds a mixin plugin to conditionally load the RecipeManager mixin only if KubeJS is not present.
 * adds a kubejs plugin to load the recipes if KubeJS *is* present.

It's annoying to have to do this but I figure that some folks might find the workaround useful.