### PR TITLE
Add config option for verbose isFootgut() logging

### DIFF
--- a/src/main/java/folk/sisby/tinkerers_smithing/TinkerersSmithingConfig.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/TinkerersSmithingConfig.java
@@ -33,4 +33,6 @@ public class TinkerersSmithingConfig extends WrappedConfig {
 		}
 		return transformedJsonString.equals(fromCrafting.toJson().toString());
 	}
+	@Comment("Print error messages? (default: false)")
+	public boolean pronounceUnloadedError = false;
 }

--- a/src/main/java/folk/sisby/tinkerers_smithing/mixin/IngredientMixin.java
+++ b/src/main/java/folk/sisby/tinkerers_smithing/mixin/IngredientMixin.java
@@ -17,11 +17,14 @@ import java.util.Arrays;
 public class IngredientMixin {
 	@Unique
 	private boolean isFootgun() {
+		boolean pronounceUnloadedError = TinkerersSmithing.CONFIG.pronounceUnloadedError;
 		Ingredient self = (Ingredient) (Object) this;
-		if (Arrays.stream(self.entries).anyMatch(e -> e instanceof Ingredient.TagEntry) && (Registries.ITEM.getEntryList(ItemTags.PLANKS).isEmpty() || Registries.ITEM.getEntryList(ItemTags.PLANKS).get().size() == 0)) {
-			TinkerersSmithing.LOGGER.error("[Tinkerer's Smithing] Cowardly refusing to access an unloaded tag ingredient: {}", self.toJson().toString(), new IllegalStateException("A tag ingredient was accessed before tags are loaded - This can break recipes! Report this to the mod in the trace below."));
-			return true;
-		}
+			if (Arrays.stream(self.entries).anyMatch(e -> e instanceof Ingredient.TagEntry) && (Registries.ITEM.getEntryList(ItemTags.PLANKS).isEmpty() || Registries.ITEM.getEntryList(ItemTags.PLANKS).get().size() == 0)) {
+				if (pronounceUnloadedError) {
+				TinkerersSmithing.LOGGER.error("[Tinkerer's Smithing] Cowardly refusing to access an unloaded tag ingredient: {}", self.toJson().toString(), new IllegalStateException("A tag ingredient was accessed before tags are loaded - This can break recipes! Report this to the mod in the trace below."));
+					}
+				return true;
+			}
 		return false;
 	}
 


### PR DESCRIPTION
As proposed [here](https://github.com/sisby-folk/tinkerers-smithing/issues/65) this small change would help with explosive logging in mod configurations using KubeJS and murphy_slaw's compat plugin in edge cases.